### PR TITLE
Unify theme and color scheme across views

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -201,11 +201,13 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 label: Text('$n'),
                 selected: selected,
                 labelStyle: TextStyle(
-                  color: selected ? Colors.white : Colors.black87, // white when selected
+                  color: selected
+                      ? theme.colorScheme.onPrimary
+                      : theme.colorScheme.onSurface,
                   fontWeight: FontWeight.w600,
                 ),
-                selectedColor: theme.colorScheme.primary, // solid brand color
-                backgroundColor: const Color(0xFFE0E0E0), // light grey when unselected
+                selectedColor: theme.colorScheme.primary,
+                backgroundColor: theme.colorScheme.surfaceVariant,
                 onSelected: (_) {
                   qty.value = n;
                   controller.text = '$n';
@@ -215,7 +217,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                   side: BorderSide(
                     color: selected
                         ? theme.colorScheme.primary
-                        : const Color(0x1F000000),
+                        : theme.colorScheme.outlineVariant,
                   ),
                 ),
               );
@@ -1144,8 +1146,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                     Expanded(
                       child: OutlinedButton(
                         style: OutlinedButton.styleFrom(
-                          foregroundColor: Colors.red,
-                          side: const BorderSide(color: Colors.red),
+                          foregroundColor: Theme.of(context).colorScheme.error,
+                          side: BorderSide(color: Theme.of(context).colorScheme.error),
                           padding: const EdgeInsets.symmetric(vertical: 14),
                           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                         ),
@@ -1157,8 +1159,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                     Expanded(
                       child: ElevatedButton(
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.green,
-                          foregroundColor: Colors.white,
+                          backgroundColor: Theme.of(context).colorScheme.primary,
+                          foregroundColor: Theme.of(context).colorScheme.onPrimary,
                           padding: const EdgeInsets.symmetric(vertical: 14),
                           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                         ),
@@ -1420,14 +1422,14 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
           child: ListView(
             children: [
               UserAccountsDrawerHeader(
-                decoration: BoxDecoration(color: theme.primaryColor),
+                decoration: BoxDecoration(color: theme.colorScheme.primary),
                 accountName: Text('$firstName $lastName'),
                 accountEmail: const Text(''),
                 currentAccountPicture: CircleAvatar(
                   backgroundColor: Colors.white,
                   child: Text(
                     firstName.isNotEmpty ? firstName[0] : '',
-                    style: TextStyle(fontSize: 40, color: theme.primaryColor),
+                    style: TextStyle(fontSize: 40, color: theme.colorScheme.primary),
                   ),
                 ),
               ),
@@ -1439,8 +1441,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
         if (_salesOrderMgrId.isNotEmpty || _invoiceMgrId.isNotEmpty) ...[
               ListTile(
-                leading: Icon(Icons.people, color: theme.primaryColor),
-                title: Text('My Customers', style: TextStyle(color: theme.primaryColor)),
+                leading: Icon(Icons.people, color: theme.colorScheme.primary),
+                title: Text('My Customers', style: TextStyle(color: theme.colorScheme.primary)),
                 onTap: () {
                   Navigator.pop(context);
                   Navigator.pushNamed(context, '/myCustomers');
@@ -1453,8 +1455,9 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
               if (_salesOrderMgrId.isNotEmpty || _invoiceMgrId.isNotEmpty) ...[
               ListTile(
-                leading: Icon(Icons.account_balance_wallet, color: theme.primaryColor),
-                title: Text('Customer Ledger', style: TextStyle(color: theme.primaryColor)),
+                leading:
+                    Icon(Icons.account_balance_wallet, color: theme.colorScheme.primary),
+                title: Text('Customer Ledger', style: TextStyle(color: theme.colorScheme.primary)),
                 onTap: () {
                   Navigator.pop(context);
                   Navigator.pushNamed(context, '/customerLedger');
@@ -1464,16 +1467,16 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               // ✅ Only show when hasSO
               if (_salesOrderMgrId.isNotEmpty) ...[
                 ListTile(
-                  leading: Icon(Icons.payments_outlined, color: theme.primaryColor),
-                  title: Text('Collections', style: TextStyle(color: theme.primaryColor)),
+                  leading: Icon(Icons.payments_outlined, color: theme.colorScheme.primary),
+                  title: Text('Collections', style: TextStyle(color: theme.colorScheme.primary)),
                   onTap: () {
                     Navigator.pop(context);
                     Navigator.pushNamed(context, '/collections');
                   },
                 ),
                 ListTile(
-                  leading: Icon(Icons.account_balance_wallet, color: theme.primaryColor),
-                  title: Text('My Sales Orders', style: TextStyle(color: theme.primaryColor)),
+                  leading: Icon(Icons.account_balance_wallet, color: theme.colorScheme.primary),
+                  title: Text('My Sales Orders', style: TextStyle(color: theme.colorScheme.primary)),
                   onTap: () {
                     Navigator.pop(context);
                     Navigator.pushNamed(context, '/mySalesOrders');
@@ -1485,8 +1488,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     if (_invoiceMgrId.isNotEmpty) ...[
 
               ListTile(
-                leading: Icon(Icons.receipt_long, color: theme.primaryColor),
-                title: Text('My Sales Invoices', style: TextStyle(color: theme.primaryColor)),
+                leading: Icon(Icons.receipt_long, color: theme.colorScheme.primary),
+                title: Text('My Sales Invoices', style: TextStyle(color: theme.colorScheme.primary)),
                 onTap: () {
                   Navigator.pop(context);
                   Navigator.pushNamed(context, '/mySalesInvoices');
@@ -1494,8 +1497,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               ),
 
       ListTile(
-        leading: Icon(Icons.payments, color: theme.primaryColor),
-        title: Text('My Cash Book', style: TextStyle(color: theme.primaryColor)),
+        leading: Icon(Icons.payments, color: theme.colorScheme.primary),
+        title: Text('My Cash Book', style: TextStyle(color: theme.colorScheme.primary)),
         onTap: () {
           Navigator.pop(context);
           Navigator.pushNamed(context, '/myCashBook');
@@ -1507,8 +1510,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
 
               ListTile(
-                leading: Icon(Icons.policy, color: theme.primaryColor),
-                title: Text('Active Policy', style: TextStyle(color: theme.primaryColor)),
+                leading: Icon(Icons.policy, color: theme.colorScheme.primary),
+                title: Text('Active Policy', style: TextStyle(color: theme.colorScheme.primary)),
                 onTap: () {
                   Navigator.pop(context);
                   Navigator.pushNamed(context, '/activePolicy');
@@ -1516,8 +1519,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               ),
 ],
               ListTile(
-                leading: Icon(Icons.money, color: theme.primaryColor),
-                title: Text('My Expenses', style: TextStyle(color: theme.primaryColor)),
+                leading: Icon(Icons.money, color: theme.colorScheme.primary),
+                title: Text('My Expenses', style: TextStyle(color: theme.colorScheme.primary)),
                 onTap: () {
                   Navigator.pop(context);
                   Navigator.pushNamed(context, '/myExpenses');
@@ -1527,8 +1530,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               const Divider(),
 
               ListTile(
-                leading: Icon(Icons.logout, color: theme.primaryColor),
-                title: Text('Logout', style: TextStyle(color: theme.primaryColor)),
+                leading: Icon(Icons.logout, color: theme.colorScheme.primary),
+                title: Text('Logout', style: TextStyle(color: theme.colorScheme.primary)),
                 onTap: () async {
                   final nav = Navigator.of(context);
                   final prefs = await SharedPreferences.getInstance();
@@ -1592,7 +1595,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide(color: Theme.of(context).primaryColor), // brand color on focus
+                  borderSide:
+                      BorderSide(color: Theme.of(context).colorScheme.primary), // brand color on focus
                 ),
                 contentPadding: const EdgeInsets.symmetric(vertical: 0, horizontal: 0),
               ),

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -62,11 +62,13 @@ class _LoginScreenState extends State<LoginScreen> {
             children: [
               Image.asset('assets/images/logo.png', height: 100),
               const SizedBox(height: 16),
-              Text('Welcome Back!',
-                  style: t.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.w800,
-                    color: Colors.white,
-                  )),
+              Text(
+                'Welcome Back!',
+                style: t.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.w800,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
               const SizedBox(height: 30),
 
               // Glass card container that matches theme InputDecoration
@@ -147,13 +149,27 @@ class _LoginScreenState extends State<LoginScreen> {
                       const SizedBox(height: 8),
                       TextButton(
                         onPressed: () {},
-                        child: const Text('Forgot password?',
-                            style: TextStyle(color: Colors.white70)),
+                        child: Text(
+                          'Forgot password?',
+                          style: TextStyle(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withOpacity(0.7),
+                          ),
+                        ),
                       ),
                       TextButton(
                         onPressed: () {},
-                        child: const Text('Don\'t have an account? Sign Up',
-                            style: TextStyle(color: Colors.white70)),
+                        child: Text(
+                          'Don\'t have an account? Sign Up',
+                          style: TextStyle(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withOpacity(0.7),
+                          ),
+                        ),
                       ),
                     ],
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'collection_screen.dart';
 import 'customer_ledger_screen.dart';
-import 'login_screen.dart';
 import 'home_screen.dart';
+import 'login_screen.dart';
 import 'my_cash_book_screen.dart';
 import 'my_customers_screen.dart';
-import 'splash_screen.dart';
-import 'my_sales_orders_screen.dart';
 import 'my_sales_invoices_screen.dart';
+import 'my_sales_orders_screen.dart';
+import 'splash_screen.dart';
+import 'theme/app_colors.dart';
+import 'theme/app_theme.dart';
 
 void main() {
   runApp(const MyApp());
@@ -18,17 +19,6 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
-
-  // Your brand colors
-  static const Color primaryColor = Color(0xFF0D47A1); // Buttons/AppBar
-  static const Color accentColor = Colors.white;
-
-  // Your login gradient colors reused app-wide
-  static const List<Color> appGradient = [
-    Color(0xFF0F2027),
-    Color(0xFF203A43),
-    Color(0xFF2C5364),
-  ];
 
   Future<bool> isTokenValid() async {
     final prefs = await SharedPreferences.getInstance();
@@ -45,63 +35,14 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final base = ThemeData(
-      useMaterial3: true,
-      // Transparent so the gradient behind shows through
-      scaffoldBackgroundColor: Colors.transparent,
-      // Keep your old primary-based styling
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: primaryColor,
-        brightness: Brightness.dark, // looks great over the dark gradient
-        primary: primaryColor,
-        onPrimary: accentColor,
-      ),
-      textTheme: GoogleFonts.poppinsTextTheme(ThemeData.dark().textTheme),
-      appBarTheme: const AppBarTheme(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        foregroundColor: Colors.white,
-        centerTitle: true,
-      ),
-      iconTheme: const IconThemeData(color: primaryColor),
-      drawerTheme: const DrawerThemeData(backgroundColor: Colors.transparent),
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ElevatedButton.styleFrom(
-          backgroundColor: primaryColor,
-          foregroundColor: accentColor,
-          padding: const EdgeInsets.symmetric(vertical: 14),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        ),
-      ),
-      floatingActionButtonTheme: const FloatingActionButtonThemeData(
-        backgroundColor: primaryColor,
-        foregroundColor: Colors.white,
-      ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
-        fillColor: Colors.white.withOpacity(0.08),
-        labelStyle: TextStyle(color: Colors.white.withOpacity(0.75)),
-        hintStyle: TextStyle(color: Colors.white.withOpacity(0.6)),
-        prefixIconColor: Colors.white,
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: Colors.white.withOpacity(0.25)),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Colors.white),
-        ),
-      ),
-    );
-
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: base,
+      theme: AppTheme.dark(),
       // Paint the gradient BEHIND all screens
       builder: (context, child) => Container(
         decoration: const BoxDecoration(
           gradient: LinearGradient(
-            colors: appGradient,
+            colors: AppColors.gradient,
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
           ),
@@ -111,7 +52,7 @@ class MyApp extends StatelessWidget {
       home: const SplashScreen(),
       routes: {
         '/login': (_) => const LoginScreen(),
-        '/home' : (_) => const HomeScreen(),
+        '/home': (_) => const HomeScreen(),
         '/mySalesOrders': (_) => const MySalesOrdersScreen(),
         '/mySalesInvoices': (_) => const MySalesInvoicesScreen(),
         '/myCashBook': (_) => const MyCashBookScreen(),

--- a/lib/my_customers_screen.dart
+++ b/lib/my_customers_screen.dart
@@ -374,8 +374,10 @@ class _MyCustomersScreenState extends State<MyCustomersScreen> {
                     alignment: Alignment.centerRight,
                     child: ElevatedButton.icon(
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Theme.of(ctx).primaryColor,
-                        foregroundColor: Colors.white,
+                        backgroundColor:
+                            Theme.of(ctx).colorScheme.primary,
+                        foregroundColor:
+                            Theme.of(ctx).colorScheme.onPrimary,
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12),
                         ),


### PR DESCRIPTION
## Summary
- Use shared `AppTheme.dark()` and gradient palette for a consistent look
- Replace hard coded button and drawer colors with theme color scheme
- Adjust login and customer views to derive text colors from theme
- Ensure quick quantity chips use theme color scheme for visible text

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/home_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76fdd65788327b9e5893362bb6708