### PR TITLE
Remove sign-up option from login screen

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -159,18 +159,6 @@ class _LoginScreenState extends State<LoginScreen> {
                           ),
                         ),
                       ),
-                      TextButton(
-                        onPressed: () {},
-                        child: Text(
-                          'Don\'t have an account? Sign Up',
-                          style: TextStyle(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withOpacity(0.7),
-                          ),
-                        ),
-                      ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Summary
- remove sign-up TextButton from login screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a775b95ff48327a55ef11cb46168ba