### PR TITLE
feat: add bottom navigation main view

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'my_sales_orders_screen.dart';
 import 'splash_screen.dart';
 import 'theme/app_colors.dart';
 import 'theme/app_theme.dart';
+import 'main_view.dart';
 
 void main() {
   runApp(const MyApp());
@@ -59,6 +60,7 @@ class MyApp extends StatelessWidget {
         '/customerLedger': (_) => const CustomerLedgerScreen(),
         '/collections': (context) => const CollectionScreen(),
         '/myCustomers': (_) => const MyCustomersScreen(),
+        '/mainView': (_) => const MainView(),
       },
     );
   }

--- a/lib/main_view.dart
+++ b/lib/main_view.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// A simple screen demonstrating a bottom navigation bar with
+/// three tabs: Users, Chat, and Call.
+class MainView extends StatefulWidget {
+  const MainView({super.key});
+
+  @override
+  State<MainView> createState() => _MainViewState();
+}
+
+class _MainViewState extends State<MainView> {
+  int _selectedIndex = 0;
+
+  static const List<Widget> _pages = <Widget>[
+    Center(child: Text('User List')),
+    Center(child: Text('Chat')),
+    Center(child: Text('Voice Call')),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.people),
+            label: 'Users',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.chat_bubble_outline),
+            label: 'Chat',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.call),
+            label: 'Call',
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add MainView screen with bottom navigation bar for Users, Chat, and Call tabs
- wire MainView into app routing

## Testing
- `dart format lib/main_view.dart lib/main.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a77faeec908327a41a216c34495a34