### PR TITLE
feat: add bottom navigation main view

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1539,9 +1539,24 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 },
               ),
             ],
-          ),
         ),
-
+        ),
+      bottomNavigationBar: const BottomNavigationBar(
+        items: [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.people),
+            label: 'Users',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.chat_bubble_outline),
+            label: 'Chat',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.call),
+            label: 'Call',
+          ),
+        ],
+      ),
 
       body: Column(
         children: [


### PR DESCRIPTION
## Summary
- add bottom navigation bar to HomeScreen with Users, Chat, and Call tabs
- remove unused MainView route and file

## Testing
- `dart format lib/main.dart lib/home_screen.dart` (fails: command not found)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68a77faeec908327a41a216c34495a34