### PR TITLE
Add SignalR connection with automatic reconnection

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'api_service.dart';
+import 'signalr_service.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -32,6 +33,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
       if (!mounted) return;
       if (response['success'] == true) {
+        await SignalRService.instance.start();
         Navigator.pushReplacementNamed(context, '/home');
       } else {
         final msg = (response['message'] ?? 'Login failed').toString();

--- a/lib/signalr_service.dart
+++ b/lib/signalr_service.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:signalr_core/signalr_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Handles connection to the SignalR chat hub with automatic reconnection.
+class SignalRService {
+  SignalRService._internal();
+  static final SignalRService instance = SignalRService._internal();
+
+  static const String _hubUrl = 'http://api.slcloud.3em.tech/chatHub';
+
+  HubConnection? _connection;
+  bool _isStarting = false;
+
+  /// Returns current SignalR connection if available.
+  HubConnection? get connection => _connection;
+
+  /// Starts the SignalR connection using the stored token.
+  Future<void> start() async {
+    if (_isStarting) return;
+    if (_connection != null &&
+        _connection!.state != HubConnectionState.disconnected) {
+      return;
+    }
+    _isStarting = true;
+
+    final prefs = await SharedPreferences.getInstance();
+    final token =
+        prefs.getString('token') ?? prefs.getString('accessToken') ?? '';
+
+    _connection = HubConnectionBuilder()
+        .withUrl(
+          _hubUrl,
+          HttpConnectionOptions(
+            accessTokenFactory: () async => token,
+          ),
+        )
+        .withAutomaticReconnect()
+        .build();
+
+    _connection!.onreconnecting((error) {
+      // ignore: avoid_print
+      print('SignalR reconnecting: ' + (error?.toString() ?? '')); 
+    });
+
+    _connection!.onreconnected((connectionId) {
+      // ignore: avoid_print
+      print('SignalR reconnected: ' + (connectionId ?? ''));
+    });
+
+    _connection!.onclose((error) {
+      // ignore: avoid_print
+      print('SignalR connection closed: ' + (error?.toString() ?? ''));
+    });
+
+    // Attempt to start the connection until it succeeds.
+    while (_connection!.state == HubConnectionState.disconnected) {
+      try {
+        await _connection!.start();
+      } catch (_) {
+        await Future.delayed(const Duration(seconds: 5));
+      }
+    }
+
+    _isStarting = false;
+  }
+
+  /// Stops the SignalR connection if active.
+  Future<void> stop() async {
+    if (_connection != null) {
+      await _connection!.stop();
+      _connection = null;
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   http: ^1.1.0
   shared_preferences: ^2.2.2
   google_fonts: ^6.1.0
+  signalr_core: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- include `signalr_core` package for SignalR support
- add `SignalRService` singleton for connecting with token and automatic reconnect
- start SignalR connection after successful login

## Testing
- `dart pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a789de3d848327ae43ae6ce3198811