### PR TITLE
Use singleton SignalR service with app lifecycle management

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -34,8 +34,7 @@ class _LoginScreenState extends State<LoginScreen> {
       if (response['success'] == true) {
         final prefs = await SharedPreferences.getInstance();
         final token = prefs.getString('token');
-        final signalRService = SignalRService();
-        await signalRService.start(token!).then((_) {
+        await SignalRService.instance.start(token!).then((_) {
           print("SignalR started!");
         }).catchError((err) {
           print("Error starting SignalR: $err");

--- a/lib/signalr_service.dart
+++ b/lib/signalr_service.dart
@@ -2,7 +2,12 @@ import 'dart:io';
 import 'package:signalr_core/signalr_core.dart';
 import 'package:http/io_client.dart';
 
+/// A simple singleton wrapper around [HubConnection] so a single
+/// SignalR connection can be shared across the entire app lifecycle.
 class SignalRService {
+  SignalRService._internal();
+  static final SignalRService instance = SignalRService._internal();
+
   HubConnection? _connection;
 
   Future<void> start(String userToken) async {


### PR DESCRIPTION
## Summary
- make `SignalRService` a singleton to share one connection across the app
- start SignalR on app launch when a token exists and stop it on app dispose
- use the shared `SignalRService.instance` after login

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae43ec92f88327b54392127f0258a5