### PR TITLE
Allow negotiation for SignalR

### DIFF
--- a/lib/signalr_service.dart
+++ b/lib/signalr_service.dart
@@ -17,7 +17,6 @@ class SignalRService {
       HttpConnectionOptions(
         accessTokenFactory: () async => userToken,
         transport: HttpTransportType.webSockets,
-        skipNegotiation: true,
       ),
     )
         .withAutomaticReconnect()


### PR DESCRIPTION
## Summary
- enable server negotiation by removing skipNegotiation flag in SignalR service

## Testing
- `dart analyze` *(fails: command not found)*
- `dart run lib/signalr_service.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae43f3a36c8327b7e7d503fe6da67d