### PR TITLE
Add integration test for SignalR hub connection

### DIFF
--- a/integration_test/signalr_connection_test.dart
+++ b/integration_test/signalr_connection_test.dart
@@ -1,0 +1,58 @@
+import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:signalr_core/signalr_core.dart';
+import 'package:slcloudapppro/api_service.dart';
+
+/// A fake implementation of [ConnectivityPlatform] so the test does not
+/// depend on host platform channels.
+class FakeConnectivity extends ConnectivityPlatform {
+  @override
+  Future<ConnectivityResult> checkConnectivity() async => ConnectivityResult.wifi;
+
+  @override
+  Stream<ConnectivityResult> get onConnectivityChanged => const Stream.empty();
+}
+
+void main() {
+  // Ensure all integration test bindings are set up.
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    // Use in-memory storage for SharedPreferences.
+    SharedPreferences.setMockInitialValues({});
+
+    // Force connectivity_plus to think we have WiFi.
+    ConnectivityPlatform.instance = FakeConnectivity();
+  });
+
+  testWidgets('connects to SignalR hub online', (tester) async {
+    // Attempt to log in to retrieve the JWT token used by the SignalR hub.
+    final login = await ApiService.attemptLogin('923212255434', 'Ba@leno99');
+    expect(login['success'], true, reason: 'Login failed');
+
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('token') ?? '';
+    expect(token.isNotEmpty, true, reason: 'Missing JWT token after login');
+
+    final hub = HubConnectionBuilder()
+        .withUrl(
+          'https://api.slcloud.3em.tech/chatHub',
+          HttpConnectionOptions(
+            transport: HttpTransportType.webSockets,
+            accessTokenFactory: () async => token,
+          ),
+        )
+        .withAutomaticReconnect([0, 2000, 5000])
+        .build();
+
+    try {
+      await hub.start();
+      expect(hub.state, HubConnectionState.connected);
+    } finally {
+      await hub.stop();
+    }
+  });
+}
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,6 +166,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -180,6 +185,11 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -264,6 +274,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -284,26 +299,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -480,6 +495,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.13.1"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   qr:
     dependency: transitive
     description:
@@ -621,6 +644,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -633,10 +664,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   tuple:
     dependency: transitive
     description:
@@ -665,10 +696,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -693,6 +724,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.5"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  integration_test:
+    sdk: flutter
 
 
 flutter:


### PR DESCRIPTION
## Summary
- add Flutter `integration_test` dependency
- create integration test that logs in and connects to the SignalR hub

## Testing
- `flutter test integration_test/signalr_connection_test.dart` *(fails: Failed to find "build/linux/x64/debug/bundle/slcloudapppro" in the search path)*

------
https://chatgpt.com/codex/tasks/task_e_68aed76de8688327b7ea854f00f3cd2b