### PR TITLE
Add sort and filter parameters when fetching Allowed IPs

### DIFF
--- a/lib/allowed_ip_screen.dart
+++ b/lib/allowed_ip_screen.dart
@@ -28,7 +28,26 @@ class _AllowedIpScreenState extends State<AllowedIpScreen> {
   Future<void> _load() async {
     setState(() => _loading = true);
     try {
-      final res = await ApiService.getAllowedIps(page: _page, pageSize: _pageSize);
+      final sort = [
+        {'dir': 'asc', 'field': 'ipAddress'},
+      ];
+      final filter = {
+        'logic': 'and',
+        'filters': [
+          {
+            'operator': 'contains',
+            'value': '',
+            'field': 'ipAddress',
+            'ignoreCase': true,
+          }
+        ],
+      };
+      final res = await ApiService.getAllowedIps(
+        page: _page,
+        pageSize: _pageSize,
+        sort: sort,
+        filter: filter,
+      );
       setState(() {
         _items = res.items;
         _totalRecords = res.totalRecords;

--- a/lib/api_service.dart
+++ b/lib/api_service.dart
@@ -809,6 +809,9 @@ class ApiService {
   static Future<PagedAllowedIp> getAllowedIps({
     int page = 1,
     int pageSize = 20,
+    List<Map<String, String>> sort = const [],
+    Map<String, dynamic>? filter,
+    bool isForDropDown = false,
   }) async {
     if (!await hasInternetConnection()) {
       throw ApiException(0, 'No internet connection.');
@@ -818,11 +821,32 @@ class ApiService {
     final token =
         prefs.getString('token') ?? prefs.getString('accessToken') ?? '';
     final payload = {
+      'isForDropDown': isForDropDown,
       'take': pageSize,
       'skip': (page - 1) * pageSize,
       'page': page,
       'pageSize': pageSize,
     };
+
+    for (int i = 0; i < sort.length; i++) {
+      final s = sort[i];
+      payload['sort[$i][dir]'] = s['dir'];
+      payload['sort[$i][field]'] = s['field'];
+    }
+
+    if (filter != null) {
+      payload['filter[logic]'] = filter['logic'];
+      final filters = filter['filters'] as List<dynamic>? ?? [];
+      for (int i = 0; i < filters.length; i++) {
+        final f = filters[i] as Map<String, dynamic>;
+        payload['filter[filters][$i][operator]'] = f['operator'];
+        payload['filter[filters][$i][value]'] = f['value'];
+        payload['filter[filters][$i][field]'] = f['field'];
+        if (f.containsKey('ignoreCase')) {
+          payload['filter[filters][$i][ignoreCase]'] = f['ignoreCase'];
+        }
+      }
+    }
 
     final resp = await _post(uri,
         headers: {


### PR DESCRIPTION
## Summary
- include `isForDropDown`, sort, and filter parameters when retrieving allowed IPs
- supply default sort by `ipAddress` and empty filter in allowed IP screen

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b2317fccb48327a89ba416bc268c8f