### PR TITLE
Add sort and filter parameters when fetching Allowed IPs

### DIFF
--- a/lib/allowed_ip_screen.dart
+++ b/lib/allowed_ip_screen.dart
@@ -28,7 +28,26 @@ class _AllowedIpScreenState extends State<AllowedIpScreen> {
   Future<void> _load() async {
     setState(() => _loading = true);
     try {
-      final res = await ApiService.getAllowedIps(page: _page, pageSize: _pageSize);
+      final sort = [
+        {'dir': 'asc', 'field': 'ipAddress'},
+      ];
+      final filter = {
+        'logic': 'and',
+        'filters': [
+          {
+            'operator': 'contains',
+            'value': '',
+            'field': 'ipAddress',
+            'ignoreCase': true,
+          }
+        ],
+      };
+      final res = await ApiService.getAllowedIps(
+        page: _page,
+        pageSize: _pageSize,
+        sort: sort,
+        filter: filter,
+      );
       setState(() {
         _items = res.items;
         _totalRecords = res.totalRecords;


### PR DESCRIPTION
## Summary
- include `isForDropDown`, sort, and filter parameters when retrieving allowed IPs
- supply default sort by `ipAddress` and empty filter in allowed IP screen
- fix sort mapping type to avoid nullability conflict

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `snap install flutter --classic` *(fails: command not found: snap)*

------
https://chatgpt.com/codex/tasks/task_e_68b2317fccb48327a89ba416bc268c8f