### PR TITLE
Add plant diagnosis camera upload screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,12 +3,14 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.CAMERA" />
 
 
     <application
         android:name="${applicationName}"
         android:label="slcloudapppro"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
 
         <activity
             android:name=".MainActivity"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,11 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSCameraUsageDescription</key>
+        <string>This app requires camera access to capture plant photos for diagnosis.</string>
+        <key>NSPhotoLibraryAddUsageDescription</key>
+        <string>Photos are saved to your library when you capture images for diagnosis.</string>
 </dict>
 </plist>

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1443,6 +1443,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 },
               ),
 
+              ListTile(
+                leading: Icon(Icons.local_florist, color: theme.primaryColor),
+                title: Text('Plant Diagnosis', style: TextStyle(color: theme.primaryColor)),
+                onTap: () {
+                  Navigator.pop(context);
+                  Navigator.pushNamed(context, '/plantDiagnosis');
+                },
+              ),
+
 
         if (_salesOrderMgrId.isNotEmpty || _invoiceMgrId.isNotEmpty) ...[
               ListTile(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'my_sales_orders_screen.dart';
 import 'my_sales_invoices_screen.dart';
 import 'signalr_service.dart';
 import 'allowed_ip_screen.dart';
+import 'plant_diagnosis_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -147,6 +148,7 @@ class _MyAppState extends State<MyApp> {
         '/collections': (context) => const CollectionScreen(),
         '/myCustomers': (_) => const MyCustomersScreen(),
         '/allowedIPs': (_) => const AllowedIpScreen(),
+        '/plantDiagnosis': (_) => const PlantDiagnosisScreen(),
       },
     );
   }

--- a/lib/plant_diagnosis_screen.dart
+++ b/lib/plant_diagnosis_screen.dart
@@ -1,0 +1,240 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
+
+class PlantDiagnosisScreen extends StatefulWidget {
+  const PlantDiagnosisScreen({super.key});
+
+  @override
+  State<PlantDiagnosisScreen> createState() => _PlantDiagnosisScreenState();
+}
+
+class _PlantDiagnosisScreenState extends State<PlantDiagnosisScreen> {
+  final ImagePicker _picker = ImagePicker();
+
+  File? _capturedImage;
+  bool _isUploading = false;
+  String? _errorMessage;
+  Map<String, dynamic>? _prediction;
+
+  Future<void> _takePhoto() async {
+    setState(() {
+      _errorMessage = null;
+      _prediction = null;
+    });
+    try {
+      final result = await _picker.pickImage(source: ImageSource.camera);
+      if (result == null) {
+        return;
+      }
+      setState(() {
+        _capturedImage = File(result.path);
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Unable to open the camera. Please try again.';
+      });
+    }
+  }
+
+  Future<void> _uploadImage() async {
+    final image = _capturedImage;
+    if (image == null) {
+      setState(() {
+        _errorMessage = 'Please capture a photo first.';
+      });
+      return;
+    }
+
+    setState(() {
+      _isUploading = true;
+      _errorMessage = null;
+      _prediction = null;
+    });
+
+    try {
+      final host = Platform.isAndroid ? '10.0.2.2' : '127.0.0.1';
+      final uri = Uri.parse('http://$host:8000/predict?top_k=5&crop_hint=tomato');
+      final request = http.MultipartRequest('POST', uri)
+        ..files.add(await http.MultipartFile.fromPath('file', image.path));
+
+      final response = await http.Response.fromStream(await request.send());
+
+      if (response.statusCode != 200) {
+        throw Exception('Server returned status ${response.statusCode}.');
+      }
+
+      final Map<String, dynamic> json = jsonDecode(response.body);
+      if (json['prediction'] is! Map<String, dynamic>) {
+        throw Exception('Unexpected response format.');
+      }
+
+      setState(() {
+        _prediction = json['prediction'] as Map<String, dynamic>;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUploading = false;
+        });
+      }
+    }
+  }
+
+  Widget _buildPredictionCard() {
+    final prediction = _prediction;
+    if (prediction == null) {
+      return const SizedBox.shrink();
+    }
+
+    final labelRaw = prediction['label_raw']?.toString() ?? 'Unknown';
+    final crop = prediction['crop']?.toString() ?? 'Unknown';
+    final disease = prediction['disease']?.toString() ?? 'Unknown';
+    final confidenceValue = prediction['confidence'];
+    final confidence = confidenceValue is num
+        ? (confidenceValue * 100).toStringAsFixed(1)
+        : 'N/A';
+
+    return Card(
+      margin: const EdgeInsets.only(top: 16),
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Prediction',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Colors.black87,
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            const SizedBox(height: 12),
+            _PredictionRow(title: 'Label', value: labelRaw),
+            _PredictionRow(title: 'Crop', value: crop),
+            _PredictionRow(title: 'Disease', value: disease),
+            _PredictionRow(title: 'Confidence', value: '$confidence%'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Plant Diagnosis'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              '1. Tap "Capture Photo" to open the camera.\n'
+              '2. Review the preview, then tap "Upload" to send the image to '
+              'the local prediction service running on your computer.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.photo_camera),
+              label: const Text('Capture Photo'),
+              onPressed: _isUploading ? null : _takePhoto,
+            ),
+            if (_capturedImage != null) ...[
+              const SizedBox(height: 16),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: Image.file(
+                  _capturedImage!,
+                  height: 280,
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              icon: _isUploading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      ),
+                    )
+                  : const Icon(Icons.cloud_upload),
+              label: Text(_isUploading ? 'Uploading...' : 'Upload'),
+              onPressed: _isUploading ? null : _uploadImage,
+            ),
+            if (_errorMessage != null) ...[
+              const SizedBox(height: 16),
+              Text(
+                _errorMessage!,
+                style: const TextStyle(color: Colors.redAccent),
+              ),
+            ],
+            _buildPredictionCard(),
+            if (Platform.isAndroid)
+              Padding(
+                padding: const EdgeInsets.only(top: 24),
+                child: Text(
+                  'Tip: The Android emulator maps your computer\'s localhost to '
+                  'http://10.0.2.2. Ensure the FastAPI server is running on your '
+                  'machine so the upload succeeds.',
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PredictionRow extends StatelessWidget {
+  const _PredictionRow({required this.title, required this.value});
+
+  final String title;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.black54,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          Flexible(
+            child: Text(
+              value,
+              textAlign: TextAlign.right,
+              style: const TextStyle(
+                color: Colors.black87,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   shared_preferences: ^2.2.2
   google_fonts: ^6.1.0
   signalr_core: ^1.1.2
+  image_picker: ^1.0.7
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add a dedicated plant diagnosis screen that captures a photo, uploads it to the localhost API, and renders the returned prediction
- register the new route in the drawer navigation and wire it into the app shell
- include camera and cleartext permissions plus iOS privacy strings and pull in the image_picker dependency

## Testing
- flutter pub get *(fails: `flutter` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd03795a80832792db7dd8a1189f84