### PR TITLE
Add in-memory kitchen ticket service with explicit status aliases

### DIFF
--- a/backend/DineSmart.Service/Kitchen/IKitchenTicketService.cs
+++ b/backend/DineSmart.Service/Kitchen/IKitchenTicketService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DtoKitchenTicketStatus = DineSmart.Dto.Kitchen.KitchenTicketStatus;
+
+namespace DineSmart.Service.Kitchen;
+
+/// <summary>
+/// Describes read/write operations that can be performed on kitchen tickets.
+/// </summary>
+public interface IKitchenTicketService
+{
+    /// <summary>
+    /// Retrieves the current status of a kitchen ticket.
+    /// </summary>
+    /// <param name="ticketId">Unique identifier of the ticket.</param>
+    /// <param name="cancellationToken">Token that indicates whether the caller no longer needs the result.</param>
+    /// <returns>The DTO representation of the ticket status.</returns>
+    Task<DtoKitchenTicketStatus> GetStatusAsync(Guid ticketId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the status of a kitchen ticket.
+    /// </summary>
+    /// <param name="ticketId">Unique identifier of the ticket.</param>
+    /// <param name="newStatus">Updated status for the ticket expressed in DTO form.</param>
+    /// <param name="cancellationToken">Token that indicates whether the caller no longer needs the result.</param>
+    Task UpdateStatusAsync(Guid ticketId, DtoKitchenTicketStatus newStatus, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the identifiers of all tickets that currently match the provided status.
+    /// </summary>
+    /// <param name="status">Status filter, expressed in DTO form.</param>
+    /// <param name="cancellationToken">Token that indicates whether the caller no longer needs the result.</param>
+    Task<IReadOnlyCollection<Guid>> GetTicketsByStatusAsync(DtoKitchenTicketStatus status, CancellationToken cancellationToken = default);
+}

--- a/backend/DineSmart.Service/Kitchen/KitchenTicketService.cs
+++ b/backend/DineSmart.Service/Kitchen/KitchenTicketService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DineSmart.Service;
+using DataKitchenTicketStatus = DineSmart.Data.Enums.KitchenTicketStatus;
+using DtoKitchenTicketStatus = DineSmart.Dto.Kitchen.KitchenTicketStatus;
+
+namespace DineSmart.Service.Kitchen;
+
+/// <summary>
+/// Provides an in-memory implementation of <see cref="IKitchenTicketService"/> that demonstrates
+/// how to work with the identically named domain and transport layer enums without triggering
+/// ambiguous reference compiler errors.
+/// </summary>
+public class KitchenTicketService : IKitchenTicketService
+{
+    private readonly ConcurrentDictionary<Guid, DataKitchenTicketStatus> _tickets = new();
+
+    /// <inheritdoc />
+    public Task<DtoKitchenTicketStatus> GetStatusAsync(Guid ticketId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_tickets.TryGetValue(ticketId, out var status))
+        {
+            throw new KeyNotFoundException($"No kitchen ticket was found for id '{ticketId}'.");
+        }
+
+        var dtoStatus = KitchenTicketStatusMapper.ToDtoStatus(status);
+        return Task.FromResult(dtoStatus);
+    }
+
+    /// <inheritdoc />
+    public Task UpdateStatusAsync(Guid ticketId, DtoKitchenTicketStatus newStatus, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var domainStatus = KitchenTicketStatusMapper.ToDomainStatus(newStatus);
+        _tickets.AddOrUpdate(ticketId, domainStatus, (_, _) => domainStatus);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<Guid>> GetTicketsByStatusAsync(DtoKitchenTicketStatus status, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var domainStatus = KitchenTicketStatusMapper.ToDomainStatus(status);
+        var matchingIds = _tickets
+            .Where(pair => pair.Value == domainStatus)
+            .Select(pair => pair.Key)
+            .ToArray();
+        return Task.FromResult<IReadOnlyCollection<Guid>>(matchingIds);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a kitchen ticket service interface that uses DTO-specific aliases to avoid ambiguous status references
- add an in-memory implementation that maps between domain and DTO kitchen ticket statuses

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f8dffd5fc883279681027a77b7a77e